### PR TITLE
Add API docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Django==1.9.5
 django-filter==0.13.0         # [r:DRF] Filters for Django REST framework
 markdown==2.6.6               # [r:DRF] Markdown. For HTML rendering of API views
 djangorestframework==3.3.3          # Django REST framework
+django-rest-swagger==0.3.5

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'bingo_server',
     # 3rd party apps
     'rest_framework',
+    'rest_framework_swagger',
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/src/src/urls.py
+++ b/src/src/urls.py
@@ -19,4 +19,5 @@ from django.contrib import admin
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api/v1/', include('api.urls')),
+    url(r'^api-docs/v1/', include('rest_framework_swagger.urls')),
 ]


### PR DESCRIPTION
Adds API documentation using Django REST Swagger. Live at `/api-docs/v1/`.
